### PR TITLE
Enhance void command handling and module import detection

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,10 +22,13 @@ The build uses Ninja for incremental compilation:
 
 ## Compilation & Linking
 WebCC acts as a wrapper around `clang++`. It:
-1.  **Scans** your code to determine which Web APIs are used.
-2.  **Generates** a tree-shaken `app.js` containing only the necessary JS glue code for the features you use.
-3.  **Compiles** your C++ code to WebAssembly.
+1.  **Compiles & links** your C++ code to WebAssembly first.
+2.  **Detects features from the linked module's import table** - never by scanning source text. Every API the code references leaves an import: return-value commands appear as real `webcc_<ns>_<func>` imports (they call into JS), and void commands appear as per-opcode marker imports in module `w`. Because the linker resolves these, detection is exact and immune to aliases, macros, or compat-header lowering (e.g. `std::cout` → `system::log`).
+3.  **Generates** a tree-shaken `app.js` containing only the necessary JS glue code for the features you use.
 4.  **Caches** compiled object files in a `.webcc_cache` directory (located inside the output directory) to speed up subsequent builds.
+
+### Void-command feature markers
+Void commands are batched through the command buffer and never call across the JS boundary, so they would leave no import on their own. To make them linker-detectable, each generated void wrapper parks the address of a tiny imported function (module `w`, field = opcode) in a `used` static. The marker is **never called** - it adds no runtime cost - but it appears in the import table if and only if that wrapper is live in the final module. The generated `app.js` supplies a shared no-op stub for each marker at instantiation.
 
 ## Resource Handles
 To maximize performance, WebCC uses **typed integer handles** to reference resources (like DOM elements, Canvases, Audio objects, and WebGL programs).

--- a/src/cli/generators.cc
+++ b/src/cli/generators.cc
@@ -721,7 +721,7 @@ namespace webcc
         std::set<std::string> used_event_listeners; // Track which event types need delegation
         std::set<std::string> used_event_helpers;   // Track which push_event helpers must exist
         std::vector<std::string> generated_js_imports;
-        std::vector<int> used_void_opcodes; // opcodes of used void commands (need import stubs)
+        bool any_void_command_used = false; // whether any void command (and thus marker import) is used
         CodeWriter cases_w;
         cases_w.set_indent(4);
 
@@ -805,7 +805,7 @@ namespace webcc
                     // (Dispatched by opcode -- no JS import needed.) Its marker
                     // import still needs a no-op stub at instantiation time.
                     gen_js_case(d, cases_w);
-                    used_void_opcodes.push_back((int)d.opcode);
+                    any_void_command_used = true;
                 }
 
                 used_namespaces.insert(d.ns);
@@ -850,18 +850,10 @@ namespace webcc
 
         // Sibling "w" import module: every used void command leaves a marker
         // import (see emit_headers) that must be supplied at instantiation even
-        // though it is never called. Provide the shared no-op for each.
-        if (!used_void_opcodes.empty())
-        {
-            std::string wmod = ",\n        w: {\n";
-            for (size_t i = 0; i < used_void_opcodes.size(); ++i)
-            {
-                wmod += "            \"" + std::to_string(used_void_opcodes[i]) + "\": _wm";
-                wmod += (i + 1 < used_void_opcodes.size()) ? ",\n" : "\n";
-            }
-            wmod += "        }";
-            w.raw(wmod);
-        }
+        // though it is never called. A Proxy returns the shared no-op for any
+        // marker name, so this stays one line no matter how many are used.
+        if (any_void_command_used)
+            w.raw(",\n        w: new Proxy({}, { get: () => _wm })");
 
         w.raw(JS_INIT_INSTANTIATE);
         w.set_indent(1);

--- a/src/cli/generators.cc
+++ b/src/cli/generators.cc
@@ -462,6 +462,17 @@ namespace webcc
                     continue;
                 }
 
+                // Per-command feature marker: an imported function (module "w",
+                // field = opcode) whose address is parked in a `used` static
+                // inside the wrapper below. It is never called -- so it costs
+                // nothing at runtime -- but it appears in the linked module's
+                // import table iff this wrapper is actually referenced by user
+                // code. That import is how generate_js_runtime detects, exactly
+                // and without scanning source text, that this void command is
+                // used (return-value commands are caught via their real import).
+                std::string mark_op = std::to_string((int)d.opcode);
+                w.write("extern \"C\" __attribute__((import_module(\"w\"), import_name(\"" + mark_op + "\"))) void __webcc_m_" + mark_op + "(void);");
+
                 // Check if we need templates for func_ptr
                 std::vector<std::string> t_params;
                 for (size_t i = 0; i < d.params.size(); ++i)
@@ -509,6 +520,7 @@ namespace webcc
                 }
                 func << "){";
                 w.write(func.str());
+                w.write("[[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_" + mark_op + ";");
                 w.write("push_command((uint32_t)OP_" + d.name + ");");
                 for (size_t i = 0; i < d.params.size(); ++i)
                 {
@@ -679,72 +691,6 @@ namespace webcc
         return events;
     }
 
-    // Replace C/C++ comments and string/char literals with spaces so the void
-    // command scan can't be fooled by an API name that appears inside a comment,
-    // a string, or a raw-string (e.g. GLSL shader source). Handles //, /* */,
-    // "...", '...', and R"delim(...)delim".
-    std::string strip_comments_and_strings(const std::string &code)
-    {
-        std::string out;
-        out.reserve(code.size());
-        size_t i = 0, n = code.size();
-        while (i < n)
-        {
-            char c = code[i];
-
-            if (c == '/' && i + 1 < n && code[i + 1] == '/') // line comment
-            {
-                i += 2;
-                while (i < n && code[i] != '\n')
-                    ++i;
-                continue;
-            }
-            if (c == '/' && i + 1 < n && code[i + 1] == '*') // block comment
-            {
-                i += 2;
-                while (i + 1 < n && !(code[i] == '*' && code[i + 1] == '/'))
-                    ++i;
-                i = (i + 2 > n) ? n : i + 2;
-                out += ' ';
-                continue;
-            }
-            if (c == 'R' && i + 1 < n && code[i + 1] == '"') // raw string R"delim(...)delim"
-            {
-                size_t j = i + 2;
-                std::string delim;
-                while (j < n && code[j] != '(' && delim.size() < 16)
-                    delim += code[j++];
-                if (j < n && code[j] == '(')
-                {
-                    std::string closer = ")" + delim + "\"";
-                    size_t end = code.find(closer, j + 1);
-                    i = (end == std::string::npos) ? n : end + closer.size();
-                    out += ' ';
-                    continue;
-                }
-                // not actually a raw string; fall through and treat 'R' normally
-            }
-            if (c == '"' || c == '\'') // string / char literal
-            {
-                char quote = c;
-                ++i;
-                while (i < n && code[i] != quote)
-                {
-                    if (code[i] == '\\' && i + 1 < n)
-                        ++i;
-                    ++i;
-                }
-                ++i; // closing quote
-                out += ' ';
-                continue;
-            }
-
-            out += c;
-            ++i;
-        }
-        return out;
-    }
-
     const std::set<std::string> &required_wasm_exports()
     {
         // Symbols the JS runtime always reads from the instantiated module.
@@ -764,7 +710,7 @@ namespace webcc
         return exports;
     }
 
-    void generate_js_runtime(const SchemaDefs &defs, const std::set<std::string> &wasm_imports, const std::string &user_code, const std::string &out_dir)
+    void generate_js_runtime(const SchemaDefs &defs, const std::set<std::string> &wasm_imports, const std::set<std::string> &void_markers, const std::string &out_dir)
     {
         CodeWriter w;
 
@@ -775,42 +721,30 @@ namespace webcc
         std::set<std::string> used_event_listeners; // Track which event types need delegation
         std::set<std::string> used_event_helpers;   // Track which push_event helpers must exist
         std::vector<std::string> generated_js_imports;
+        std::vector<int> used_void_opcodes; // opcodes of used void commands (need import stubs)
         CodeWriter cases_w;
         cases_w.set_indent(4);
 
-        // Detect which commands are used. The two kinds of command leave
-        // different traces, so we use the right tool for each:
+        // Detect which commands are used entirely from the linked module's
+        // import table -- no source scanning. Both kinds of command leave an
+        // import when (and only when) the user's code references them:
         //   * Return-value commands are real wasm imports (webcc_<ns>_<func>),
-        //     read straight from the linked module's import table. Exact, and
-        //     impossible to desync from what the module actually needs.
-        //   * Void commands are dispatched by opcode through the shared
-        //     webcc_js_flush import and leave no unique symbol, so we fall back
-        //     to scanning the user source -- with comments and string literals
-        //     stripped first to avoid false positives -- for a qualified call.
-        std::string scan_code = strip_comments_and_strings(user_code);
+        //     called directly from the wrapper.
+        //   * Void commands are batched and never call across the boundary, so
+        //     each wrapper instead parks the address of a per-command marker
+        //     import (module "w", field = opcode) in a `used` static. The
+        //     marker is never called, but it appears in the import table iff
+        //     the wrapper is live -- which `void_markers` reflects exactly.
+        // This is immune to aliases, macros, and compat-header lowering (e.g.
+        // std::cout -> system::log) that a text scan would silently miss.
 
         for (const auto &d : defs.commands)
         {
             bool used;
             if (!d.return_type.empty())
-            {
                 used = wasm_imports.count("webcc_" + d.ns + "_" + d.func_name) > 0;
-            }
             else
-            {
-                used = contains_whole_word(scan_code, d.ns + "::" + d.func_name) ||
-                       contains_whole_word(scan_code, "webcc::" + d.ns + "::" + d.func_name);
-
-                // std::cout / std::cerr lower to webcc::system::log / error via
-                // the iostream compat header, so the qualified name never appears
-                // in user code. (std::chrono -> get_time / get_date_now needs no
-                // special case: those are return commands, caught via imports.)
-                if (!used && d.ns == "system" && (d.func_name == "log" || d.func_name == "error"))
-                {
-                    used = contains_whole_word(scan_code, "std::cout") ||
-                           contains_whole_word(scan_code, "std::cerr");
-                }
-            }
+                used = void_markers.count(std::to_string((int)d.opcode)) > 0;
 
             if (!used)
                 continue;
@@ -868,8 +802,10 @@ namespace webcc
                 else
                 {
                     // For commands without a return value, generate a case in the flush switch.
-                    // (Dispatched by opcode -- no JS import needed.)
+                    // (Dispatched by opcode -- no JS import needed.) Its marker
+                    // import still needs a no-op stub at instantiation time.
                     gen_js_case(d, cases_w);
+                    used_void_opcodes.push_back((int)d.opcode);
                 }
 
                 used_namespaces.insert(d.ns);
@@ -910,7 +846,24 @@ namespace webcc
             w.raw(",\n");
             w.write(imp);
         }
-        w.raw(JS_INIT_TAIL);
+        w.raw(JS_INIT_ENV_CLOSE);
+
+        // Sibling "w" import module: every used void command leaves a marker
+        // import (see emit_headers) that must be supplied at instantiation even
+        // though it is never called. Provide the shared no-op for each.
+        if (!used_void_opcodes.empty())
+        {
+            std::string wmod = ",\n        w: {\n";
+            for (size_t i = 0; i < used_void_opcodes.size(); ++i)
+            {
+                wmod += "            \"" + std::to_string(used_void_opcodes[i]) + "\": _wm";
+                wmod += (i + 1 < used_void_opcodes.size()) ? ",\n" : "\n";
+            }
+            wmod += "        }";
+            w.raw(wmod);
+        }
+
+        w.raw(JS_INIT_INSTANTIATE);
         w.set_indent(1);
 
         // Generate single unified exports destructuring
@@ -1293,6 +1246,18 @@ namespace webcc
         std::string object_files_str;
         bool compilation_failed = false;
 
+        // Toolchain-version guard for the object cache. The cache keys only on
+        // source mtime, so a rebuilt webcc -- or headers regenerated in the same
+        // build step -- would otherwise leave stale objects in place. That now
+        // matters for correctness, not just freshness: feature detection reads
+        // per-command markers out of the compiled object, so a stale object
+        // compiled against old headers silently under-detects commands. Treat
+        // the webcc binary's mtime as the toolchain version and recompile any
+        // object older than it. (Only triggers right after a toolchain rebuild;
+        // ordinary app edits leave the binary's mtime untouched.)
+        struct stat exe_stat;
+        bool have_exe_mtime = (stat(get_executable_path().c_str(), &exe_stat) == 0);
+
         for (const auto &src : all_sources)
         {
             std::string obj_name = src;
@@ -1308,7 +1273,8 @@ namespace webcc
             {
                 if (stat(obj.c_str(), &obj_stat) == 0)
                 {
-                    if (obj_stat.st_mtime >= src_stat.st_mtime)
+                    if (obj_stat.st_mtime >= src_stat.st_mtime &&
+                        (!have_exe_mtime || obj_stat.st_mtime >= exe_stat.st_mtime))
                         need_compile = false;
                 }
             }

--- a/src/cli/generators.h
+++ b/src/cli/generators.h
@@ -25,11 +25,12 @@ namespace webcc
     bool contains_whole_word(const std::string &text, const std::string &word);
 
     // Generates the JavaScript runtime (app.js) based on used commands.
-    // Return-value commands are detected from `wasm_imports` (the import field
-    // names of the linked module, see read_wasm_imports); void commands are
-    // detected by scanning `user_code` (comments/strings stripped) for a
-    // qualified call.
-    void generate_js_runtime(const SchemaDefs &defs, const std::set<std::string> &wasm_imports, const std::string &user_code, const std::string &out_dir);
+    // Both command kinds are detected from the linked module's import table:
+    // return-value commands appear as `webcc_<ns>_<func>` imports in `env`
+    // (`wasm_imports`); void commands appear as per-opcode marker imports in
+    // module "w" (`void_markers`, field name = decimal opcode). See
+    // read_wasm_imports and emit_headers.
+    void generate_js_runtime(const SchemaDefs &defs, const std::set<std::string> &wasm_imports, const std::set<std::string> &void_markers, const std::string &out_dir);
 
     // Generates the HTML scaffolding (index.html).
     // If a template file exists (index.template.html), uses it and injects the script tag.

--- a/src/cli/js_templates.h
+++ b/src/cli/js_templates.h
@@ -21,6 +21,7 @@ const run = async () => {
     const assetBase = new URL('.', scriptSrc || window.location.href);
     const wasmUrl = new URL('app.wasm', assetBase);
 
+    const _wm = () => {}; // shared no-op for void-command feature markers (never called)
     const imports = {
         env: {
             // C++ calls this function to tell JS "I wrote commands, please execute them"
@@ -31,10 +32,15 @@ const run = async () => {
             __cxa_finalize: () => {}
 )";
 
+    // Closes the `env` import object. The generator may then append sibling
+    // import modules (e.g. the "w" marker-stub module) before JS_INIT_INSTANTIATE
+    // closes the `imports` object and instantiates the module.
+    const std::string JS_INIT_ENV_CLOSE = R"(
+        })";
+
     // JS code to finalize WASM instantiation.
     // Note: The exports destructuring is now generated dynamically based on what's needed.
-    const std::string JS_INIT_TAIL = R"(
-        }
+    const std::string JS_INIT_INSTANTIATE = R"(
     };
 
     let mod;

--- a/src/cli/main.cc
+++ b/src/cli/main.cc
@@ -104,31 +104,30 @@ int main(int argc, char **argv)
     std::string schema_cache_path = exe_dir + "/schema.wcc.bin";
     defs = webcc::load_defs_cached(schema_cache_path, defs_path);
 
-    // A. READ USER CODE (all files), concatenated for the void-command scan.
-    std::string user_code;
-    for (const auto &path : input_files)
-        user_code += webcc::read_file(path) + "\n";
-
-    // B. COMPILE C++ TO WASM (Incremental).
+    // A. COMPILE C++ TO WASM (Incremental).
     // Link first, with a constant set of exports, so the linked module's import
-    // table becomes the ground-truth list of return-value commands the user's
-    // code references (the compiler resolves those names; we never guess them).
+    // table becomes the ground-truth list of commands the user's code references
+    // (the compiler/linker resolves those names; we never guess them).
     if (!webcc::compile_wasm(input_files, out_dir, cache_dir, webcc::required_wasm_exports()))
     {
         return 1;
     }
 
-    // C. READ the linked wasm's import table (return-value command detection).
+    // B. READ the linked wasm's import table for feature detection.
+    //    env."webcc_<ns>_<func>"  -> return-value commands (real imports)
+    //    w."<opcode>"             -> void commands (per-opcode marker imports)
     std::string wasm_path = out_dir + "/app.wasm";
     std::set<std::string> wasm_imports;
-    if (!webcc::read_wasm_imports(wasm_path, wasm_imports))
+    std::set<std::string> void_markers;
+    if (!webcc::read_wasm_imports(wasm_path, wasm_imports) ||
+        !webcc::read_wasm_imports(wasm_path, void_markers, "w"))
     {
         std::cerr << "[WebCC] Error: Could not read imports from " << wasm_path << std::endl;
         return 1;
     }
 
-    // D. GENERATE JS RUNTIME (return cmds from imports; void cmds from source).
-    webcc::generate_js_runtime(defs, wasm_imports, user_code, out_dir);
+    // C. GENERATE JS RUNTIME (both command kinds detected from the import table).
+    webcc::generate_js_runtime(defs, wasm_imports, void_markers, out_dir);
 
     // E. GENERATE HTML (Basic scaffolding).
     webcc::generate_html(out_dir, template_path);

--- a/tests/snapshots/app_canvas.js
+++ b/tests/snapshots/app_canvas.js
@@ -14,6 +14,7 @@ const run = async () => {
     const assetBase = new URL('.', scriptSrc || window.location.href);
     const wasmUrl = new URL('app.wasm', assetBase);
 
+    const _wm = () => {}; // shared no-op for void-command feature markers (never called)
     const imports = {
         env: {
             // C++ calls this function to tell JS "I wrote commands, please execute them"
@@ -32,6 +33,9 @@ const run = async () => {
                 const handle = (window.webcc_next_id = (window.webcc_next_id || 0) + 1); const c = elements[canvas_handle]; if(!c) { console.warn('get_context_2d: unknown canvas', canvas_handle); return -1; } contexts[handle] = c.getContext('2d'); return handle;
             }
 
+        },
+        w: {
+            "37": _wm
         }
     };
 

--- a/tests/snapshots/app_canvas.js
+++ b/tests/snapshots/app_canvas.js
@@ -34,9 +34,7 @@ const run = async () => {
             }
 
         },
-        w: {
-            "37": _wm
-        }
+        w: new Proxy({}, { get: () => _wm })
     };
 
     let mod;

--- a/tests/snapshots/app_dom.js
+++ b/tests/snapshots/app_dom.js
@@ -34,10 +34,7 @@ const run = async () => {
             }
 
         },
-        w: {
-            "15": _wm,
-            "20": _wm
-        }
+        w: new Proxy({}, { get: () => _wm })
     };
 
     let mod;

--- a/tests/snapshots/app_dom.js
+++ b/tests/snapshots/app_dom.js
@@ -14,6 +14,7 @@ const run = async () => {
     const assetBase = new URL('.', scriptSrc || window.location.href);
     const wasmUrl = new URL('app.wasm', assetBase);
 
+    const _wm = () => {}; // shared no-op for void-command feature markers (never called)
     const imports = {
         env: {
             // C++ calls this function to tell JS "I wrote commands, please execute them"
@@ -32,6 +33,10 @@ const run = async () => {
                 const handle = (window.webcc_next_id = (window.webcc_next_id || 0) + 1); const el = document.createElement(tag); elements[handle] = el; return handle;
             }
 
+        },
+        w: {
+            "15": _wm,
+            "20": _wm
         }
     };
 

--- a/tests/snapshots/canvas.h
+++ b/tests/snapshots/canvas.h
@@ -86,14 +86,18 @@ namespace webcc::canvas {
         return webcc::WGPUContext(webcc_canvas_get_context_webgpu((int32_t)canvas_handle));
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("34"))) void __webcc_m_34(void);
     inline void set_size(webcc::Canvas handle, double width, double height){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_34;
         push_command((uint32_t)OP_SET_SIZE);
         push_data<int32_t>((int32_t)handle);
         push_data<double>(width);
         push_data<double>(height);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("35"))) void __webcc_m_35(void);
     inline void set_fill_style(webcc::CanvasContext2D handle, uint8_t r, uint8_t g, uint8_t b){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_35;
         push_command((uint32_t)OP_SET_FILL_STYLE);
         push_data<int32_t>((int32_t)handle);
         push_data<uint32_t>((uint32_t)r);
@@ -101,13 +105,17 @@ namespace webcc::canvas {
         push_data<uint32_t>((uint32_t)b);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("36"))) void __webcc_m_36(void);
     inline void set_fill_style_str(webcc::CanvasContext2D handle, webcc::string_view color){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_36;
         push_command((uint32_t)OP_SET_FILL_STYLE_STR);
         push_data<int32_t>((int32_t)handle);
         webcc::CommandBuffer::push_string(color.data(), color.length());
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("37"))) void __webcc_m_37(void);
     inline void fill_rect(webcc::CanvasContext2D handle, double x, double y, double w, double h){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_37;
         push_command((uint32_t)OP_FILL_RECT);
         push_data<int32_t>((int32_t)handle);
         push_data<double>(x);
@@ -116,7 +124,9 @@ namespace webcc::canvas {
         push_data<double>(h);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("38"))) void __webcc_m_38(void);
     inline void clear_rect(webcc::CanvasContext2D handle, double x, double y, double w, double h){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_38;
         push_command((uint32_t)OP_CLEAR_RECT);
         push_data<int32_t>((int32_t)handle);
         push_data<double>(x);
@@ -125,7 +135,9 @@ namespace webcc::canvas {
         push_data<double>(h);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("39"))) void __webcc_m_39(void);
     inline void stroke_rect(webcc::CanvasContext2D handle, double x, double y, double w, double h){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_39;
         push_command((uint32_t)OP_STROKE_RECT);
         push_data<int32_t>((int32_t)handle);
         push_data<double>(x);
@@ -134,7 +146,9 @@ namespace webcc::canvas {
         push_data<double>(h);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("40"))) void __webcc_m_40(void);
     inline void set_stroke_style(webcc::CanvasContext2D handle, uint8_t r, uint8_t g, uint8_t b){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_40;
         push_command((uint32_t)OP_SET_STROKE_STYLE);
         push_data<int32_t>((int32_t)handle);
         push_data<uint32_t>((uint32_t)r);
@@ -142,53 +156,71 @@ namespace webcc::canvas {
         push_data<uint32_t>((uint32_t)b);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("41"))) void __webcc_m_41(void);
     inline void set_stroke_style_str(webcc::CanvasContext2D handle, webcc::string_view color){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_41;
         push_command((uint32_t)OP_SET_STROKE_STYLE_STR);
         push_data<int32_t>((int32_t)handle);
         webcc::CommandBuffer::push_string(color.data(), color.length());
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("42"))) void __webcc_m_42(void);
     inline void set_line_width(webcc::CanvasContext2D handle, double width){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_42;
         push_command((uint32_t)OP_SET_LINE_WIDTH);
         push_data<int32_t>((int32_t)handle);
         push_data<double>(width);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("43"))) void __webcc_m_43(void);
     inline void begin_path(webcc::CanvasContext2D handle){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_43;
         push_command((uint32_t)OP_BEGIN_PATH);
         push_data<int32_t>((int32_t)handle);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("44"))) void __webcc_m_44(void);
     inline void close_path(webcc::CanvasContext2D handle){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_44;
         push_command((uint32_t)OP_CLOSE_PATH);
         push_data<int32_t>((int32_t)handle);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("45"))) void __webcc_m_45(void);
     inline void move_to(webcc::CanvasContext2D handle, double x, double y){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_45;
         push_command((uint32_t)OP_MOVE_TO);
         push_data<int32_t>((int32_t)handle);
         push_data<double>(x);
         push_data<double>(y);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("46"))) void __webcc_m_46(void);
     inline void line_to(webcc::CanvasContext2D handle, double x, double y){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_46;
         push_command((uint32_t)OP_LINE_TO);
         push_data<int32_t>((int32_t)handle);
         push_data<double>(x);
         push_data<double>(y);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("47"))) void __webcc_m_47(void);
     inline void stroke(webcc::CanvasContext2D handle){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_47;
         push_command((uint32_t)OP_STROKE);
         push_data<int32_t>((int32_t)handle);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("48"))) void __webcc_m_48(void);
     inline void fill(webcc::CanvasContext2D handle){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_48;
         push_command((uint32_t)OP_FILL);
         push_data<int32_t>((int32_t)handle);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("49"))) void __webcc_m_49(void);
     inline void arc(webcc::CanvasContext2D handle, double x, double y, double radius, double start_angle, double end_angle){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_49;
         push_command((uint32_t)OP_ARC);
         push_data<int32_t>((int32_t)handle);
         push_data<double>(x);
@@ -198,7 +230,9 @@ namespace webcc::canvas {
         push_data<double>(end_angle);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("50"))) void __webcc_m_50(void);
     inline void fill_text(webcc::CanvasContext2D handle, webcc::string_view text, double x, double y){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_50;
         push_command((uint32_t)OP_FILL_TEXT);
         push_data<int32_t>((int32_t)handle);
         webcc::CommandBuffer::push_string(text.data(), text.length());
@@ -206,7 +240,9 @@ namespace webcc::canvas {
         push_data<double>(y);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("51"))) void __webcc_m_51(void);
     inline void fill_text_f(webcc::CanvasContext2D handle, webcc::string_view fmt, double val, double x, double y){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_51;
         push_command((uint32_t)OP_FILL_TEXT_F);
         push_data<int32_t>((int32_t)handle);
         webcc::CommandBuffer::push_string(fmt.data(), fmt.length());
@@ -215,7 +251,9 @@ namespace webcc::canvas {
         push_data<double>(y);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("52"))) void __webcc_m_52(void);
     inline void fill_text_i(webcc::CanvasContext2D handle, webcc::string_view fmt, int32_t val, double x, double y){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_52;
         push_command((uint32_t)OP_FILL_TEXT_I);
         push_data<int32_t>((int32_t)handle);
         webcc::CommandBuffer::push_string(fmt.data(), fmt.length());
@@ -224,19 +262,25 @@ namespace webcc::canvas {
         push_data<double>(y);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("53"))) void __webcc_m_53(void);
     inline void set_font(webcc::CanvasContext2D handle, webcc::string_view font){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_53;
         push_command((uint32_t)OP_SET_FONT);
         push_data<int32_t>((int32_t)handle);
         webcc::CommandBuffer::push_string(font.data(), font.length());
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("54"))) void __webcc_m_54(void);
     inline void set_text_align(webcc::CanvasContext2D handle, webcc::string_view align){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_54;
         push_command((uint32_t)OP_SET_TEXT_ALIGN);
         push_data<int32_t>((int32_t)handle);
         webcc::CommandBuffer::push_string(align.data(), align.length());
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("55"))) void __webcc_m_55(void);
     inline void draw_image(webcc::CanvasContext2D handle, webcc::Image img_handle, double x, double y){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_55;
         push_command((uint32_t)OP_DRAW_IMAGE);
         push_data<int32_t>((int32_t)handle);
         push_data<int32_t>((int32_t)img_handle);
@@ -244,60 +288,80 @@ namespace webcc::canvas {
         push_data<double>(y);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("56"))) void __webcc_m_56(void);
     inline void translate(webcc::CanvasContext2D handle, double x, double y){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_56;
         push_command((uint32_t)OP_TRANSLATE);
         push_data<int32_t>((int32_t)handle);
         push_data<double>(x);
         push_data<double>(y);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("57"))) void __webcc_m_57(void);
     inline void rotate(webcc::CanvasContext2D handle, double angle){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_57;
         push_command((uint32_t)OP_ROTATE);
         push_data<int32_t>((int32_t)handle);
         push_data<double>(angle);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("58"))) void __webcc_m_58(void);
     inline void scale(webcc::CanvasContext2D handle, double x, double y){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_58;
         push_command((uint32_t)OP_SCALE);
         push_data<int32_t>((int32_t)handle);
         push_data<double>(x);
         push_data<double>(y);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("59"))) void __webcc_m_59(void);
     inline void save(webcc::CanvasContext2D handle){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_59;
         push_command((uint32_t)OP_SAVE);
         push_data<int32_t>((int32_t)handle);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("60"))) void __webcc_m_60(void);
     inline void restore(webcc::CanvasContext2D handle){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_60;
         push_command((uint32_t)OP_RESTORE);
         push_data<int32_t>((int32_t)handle);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("61"))) void __webcc_m_61(void);
     inline void log_canvas_info(webcc::Canvas handle){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_61;
         push_command((uint32_t)OP_LOG_CANVAS_INFO);
         push_data<int32_t>((int32_t)handle);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("62"))) void __webcc_m_62(void);
     inline void set_global_alpha(webcc::CanvasContext2D handle, double alpha){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_62;
         push_command((uint32_t)OP_SET_GLOBAL_ALPHA);
         push_data<int32_t>((int32_t)handle);
         push_data<double>(alpha);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("63"))) void __webcc_m_63(void);
     inline void set_line_cap(webcc::CanvasContext2D handle, webcc::string_view cap){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_63;
         push_command((uint32_t)OP_SET_LINE_CAP);
         push_data<int32_t>((int32_t)handle);
         webcc::CommandBuffer::push_string(cap.data(), cap.length());
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("64"))) void __webcc_m_64(void);
     inline void set_line_join(webcc::CanvasContext2D handle, webcc::string_view join){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_64;
         push_command((uint32_t)OP_SET_LINE_JOIN);
         push_data<int32_t>((int32_t)handle);
         webcc::CommandBuffer::push_string(join.data(), join.length());
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("65"))) void __webcc_m_65(void);
     inline void set_shadow(webcc::CanvasContext2D handle, double blur, double off_x, double off_y, webcc::string_view color){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_65;
         push_command((uint32_t)OP_SET_SHADOW);
         push_data<int32_t>((int32_t)handle);
         push_data<double>(blur);
@@ -306,7 +370,9 @@ namespace webcc::canvas {
         webcc::CommandBuffer::push_string(color.data(), color.length());
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("66"))) void __webcc_m_66(void);
     inline void bezier_curve_to(webcc::CanvasContext2D handle, double cp1x, double cp1y, double cp2x, double cp2y, double x, double y){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_66;
         push_command((uint32_t)OP_BEZIER_CURVE_TO);
         push_data<int32_t>((int32_t)handle);
         push_data<double>(cp1x);
@@ -317,7 +383,9 @@ namespace webcc::canvas {
         push_data<double>(y);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("67"))) void __webcc_m_67(void);
     inline void quadratic_curve_to(webcc::CanvasContext2D handle, double cpx, double cpy, double x, double y){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_67;
         push_command((uint32_t)OP_QUADRATIC_CURVE_TO);
         push_data<int32_t>((int32_t)handle);
         push_data<double>(cpx);
@@ -326,7 +394,9 @@ namespace webcc::canvas {
         push_data<double>(y);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("68"))) void __webcc_m_68(void);
     inline void rect(webcc::CanvasContext2D handle, double x, double y, double w, double h){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_68;
         push_command((uint32_t)OP_RECT);
         push_data<int32_t>((int32_t)handle);
         push_data<double>(x);
@@ -335,12 +405,16 @@ namespace webcc::canvas {
         push_data<double>(h);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("69"))) void __webcc_m_69(void);
     inline void clip(webcc::CanvasContext2D handle){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_69;
         push_command((uint32_t)OP_CLIP);
         push_data<int32_t>((int32_t)handle);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("70"))) void __webcc_m_70(void);
     inline void stroke_text(webcc::CanvasContext2D handle, webcc::string_view text, double x, double y){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_70;
         push_command((uint32_t)OP_STROKE_TEXT);
         push_data<int32_t>((int32_t)handle);
         webcc::CommandBuffer::push_string(text.data(), text.length());
@@ -348,19 +422,25 @@ namespace webcc::canvas {
         push_data<double>(y);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("71"))) void __webcc_m_71(void);
     inline void set_text_baseline(webcc::CanvasContext2D handle, webcc::string_view baseline){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_71;
         push_command((uint32_t)OP_SET_TEXT_BASELINE);
         push_data<int32_t>((int32_t)handle);
         webcc::CommandBuffer::push_string(baseline.data(), baseline.length());
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("72"))) void __webcc_m_72(void);
     inline void set_global_composite_operation(webcc::CanvasContext2D handle, webcc::string_view op){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_72;
         push_command((uint32_t)OP_SET_GLOBAL_COMPOSITE_OPERATION);
         push_data<int32_t>((int32_t)handle);
         webcc::CommandBuffer::push_string(op.data(), op.length());
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("73"))) void __webcc_m_73(void);
     inline void draw_image_scaled(webcc::CanvasContext2D handle, webcc::Image img_handle, double x, double y, double w, double h){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_73;
         push_command((uint32_t)OP_DRAW_IMAGE_SCALED);
         push_data<int32_t>((int32_t)handle);
         push_data<int32_t>((int32_t)img_handle);
@@ -370,7 +450,9 @@ namespace webcc::canvas {
         push_data<double>(h);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("74"))) void __webcc_m_74(void);
     inline void draw_image_full(webcc::CanvasContext2D handle, webcc::Image img_handle, double sx, double sy, double sw, double sh, double dx, double dy, double dw, double dh){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_74;
         push_command((uint32_t)OP_DRAW_IMAGE_FULL);
         push_data<int32_t>((int32_t)handle);
         push_data<int32_t>((int32_t)img_handle);
@@ -384,12 +466,16 @@ namespace webcc::canvas {
         push_data<double>(dh);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("75"))) void __webcc_m_75(void);
     inline void reset_transform(webcc::CanvasContext2D handle){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_75;
         push_command((uint32_t)OP_RESET_TRANSFORM);
         push_data<int32_t>((int32_t)handle);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("76"))) void __webcc_m_76(void);
     inline void ellipse(webcc::CanvasContext2D handle, double x, double y, double radius_x, double radius_y, double rotation, double start_angle, double end_angle, uint8_t counter_clockwise){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_76;
         push_command((uint32_t)OP_ELLIPSE);
         push_data<int32_t>((int32_t)handle);
         push_data<double>(x);
@@ -402,7 +488,9 @@ namespace webcc::canvas {
         push_data<uint32_t>((uint32_t)counter_clockwise);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("77"))) void __webcc_m_77(void);
     inline void arc_to(webcc::CanvasContext2D handle, double x1, double y1, double x2, double y2, double radius){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_77;
         push_command((uint32_t)OP_ARC_TO);
         push_data<int32_t>((int32_t)handle);
         push_data<double>(x1);
@@ -412,7 +500,9 @@ namespace webcc::canvas {
         push_data<double>(radius);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("78"))) void __webcc_m_78(void);
     inline void set_transform(webcc::CanvasContext2D handle, double a, double b, double c, double d, double e, double f){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_78;
         push_command((uint32_t)OP_SET_TRANSFORM);
         push_data<int32_t>((int32_t)handle);
         push_data<double>(a);
@@ -423,7 +513,9 @@ namespace webcc::canvas {
         push_data<double>(f);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("79"))) void __webcc_m_79(void);
     inline void transform(webcc::CanvasContext2D handle, double a, double b, double c, double d, double e, double f){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_79;
         push_command((uint32_t)OP_TRANSFORM);
         push_data<int32_t>((int32_t)handle);
         push_data<double>(a);
@@ -434,13 +526,17 @@ namespace webcc::canvas {
         push_data<double>(f);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("80"))) void __webcc_m_80(void);
     inline void set_miter_limit(webcc::CanvasContext2D handle, double limit){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_80;
         push_command((uint32_t)OP_SET_MITER_LIMIT);
         push_data<int32_t>((int32_t)handle);
         push_data<double>(limit);
     }
 
+    extern "C" __attribute__((import_module("w"), import_name("81"))) void __webcc_m_81(void);
     inline void set_image_smoothing_enabled(webcc::CanvasContext2D handle, uint8_t enabled){
+        [[maybe_unused]] static void (*const __webcc_keep)(void) __attribute__((used)) = &__webcc_m_81;
         push_command((uint32_t)OP_SET_IMAGE_SMOOTHING_ENABLED);
         push_data<int32_t>((int32_t)handle);
         push_data<uint32_t>((uint32_t)enabled);

--- a/tests/test_codegen.cc
+++ b/tests/test_codegen.cc
@@ -83,27 +83,34 @@ namespace
     {
         return load_defs(std::string(WEBCC_SCHEMA_DEF));
     }
+
+    // Build the module-"w" marker set (opcode strings) for the given void
+    // commands, mirroring what the linker emits when those wrappers are
+    // referenced by user code. generate_js_runtime detects void commands from
+    // this set, exactly as it does from the real wasm import table.
+    std::set<std::string> void_markers(const SchemaDefs &defs,
+                                       const std::set<std::string> &qualified_names)
+    {
+        std::set<std::string> out;
+        for (const auto &c : defs.commands)
+            if (qualified_names.count(c.ns + "::" + c.func_name))
+                out.insert(std::to_string((int)c.opcode));
+        return out;
+    }
 }
 
 TEST(codegen_js_canvas_snapshot)
 {
     SchemaDefs defs = real_defs();
     // A canvas-only program. Return commands are detected from the linker import
-    // set; void commands (fill_rect) are detected by scanning the source.
+    // set; void commands (fill_rect) are detected from their module-"w" markers.
     std::set<std::string> imports = {
         "webcc_js_flush",
         "webcc_canvas_create_canvas",
         "webcc_canvas_get_context_2d",
     };
-    std::string user = R"(
-        #include "webcc/canvas.h"
-        int main() {
-            auto c = webcc::canvas::create_canvas("c", 640, 480);
-            auto ctx = webcc::canvas::get_context_2d(c);
-            webcc::canvas::fill_rect(ctx, 0, 0, 100, 100);
-        }
-    )";
-    generate_js_runtime(defs, imports, user, "/tmp");
+    auto markers = void_markers(defs, {"canvas::fill_rect"});
+    generate_js_runtime(defs, imports, markers, "/tmp");
     std::string js = read_file("/tmp/app.js");
     check_snapshot("app_canvas.js", js);
 }
@@ -111,21 +118,14 @@ TEST(codegen_js_canvas_snapshot)
 TEST(codegen_js_treeshakes_unused_modules)
 {
     SchemaDefs defs = real_defs();
-    // Same canvas-only program as above (return imports + source for void cmds).
+    // Same canvas-only program as above (return imports + void-command markers).
     std::set<std::string> imports = {
         "webcc_js_flush",
         "webcc_canvas_create_canvas",
         "webcc_canvas_get_context_2d",
     };
-    std::string user = R"(
-        #include "webcc/canvas.h"
-        int main() {
-            auto c = webcc::canvas::create_canvas("c", 640, 480);
-            auto ctx = webcc::canvas::get_context_2d(c);
-            webcc::canvas::fill_rect(ctx, 0, 0, 100, 100);
-        }
-    )";
-    generate_js_runtime(defs, imports, user, "/tmp");
+    auto markers = void_markers(defs, {"canvas::fill_rect"});
+    generate_js_runtime(defs, imports, markers, "/tmp");
     std::string js = read_file("/tmp/app.js");
 
     // Canvas code IS present...
@@ -147,16 +147,8 @@ TEST(codegen_js_emits_event_delegation_only_when_used)
         "webcc_dom_get_body",
         "webcc_dom_create_element",
     };
-    std::string user = R"(
-        #include "webcc/dom.h"
-        int main() {
-            auto b = webcc::dom::get_body();
-            auto btn = webcc::dom::create_element("button");
-            webcc::dom::append_child(b, btn);
-            webcc::dom::add_click_listener(btn);
-        }
-    )";
-    generate_js_runtime(defs, imports, user, "/tmp");
+    auto markers = void_markers(defs, {"dom::append_child", "dom::add_click_listener"});
+    generate_js_runtime(defs, imports, markers, "/tmp");
     std::string js = read_file("/tmp/app.js");
 
     // Click delegation wired up; keydown delegation not (unused).
@@ -174,16 +166,8 @@ TEST(codegen_dom_user_snapshot)
         "webcc_dom_get_body",
         "webcc_dom_create_element",
     };
-    std::string user = R"(
-        #include "webcc/dom.h"
-        int main() {
-            auto b = webcc::dom::get_body();
-            auto d = webcc::dom::create_element("div");
-            webcc::dom::set_inner_text(d, "hello");
-            webcc::dom::append_child(b, d);
-        }
-    )";
-    generate_js_runtime(defs, imports, user, "/tmp");
+    auto markers = void_markers(defs, {"dom::set_inner_text", "dom::append_child"});
+    generate_js_runtime(defs, imports, markers, "/tmp");
     std::string js = read_file("/tmp/app.js");
     check_snapshot("app_dom.js", js);
 }


### PR DESCRIPTION
This pull request significantly refactors how WebCC detects and generates JavaScript glue code for used Web APIs, moving from source code scanning to reading the linked WebAssembly module's import table. This makes feature detection more robust, exact, and immune to aliases or macro-based indirection. It also introduces per-command marker imports for void commands, improves cache correctness, and cleans up the build and code structure.

**Feature detection and JS runtime generation:**

* Feature detection now relies entirely on the linked WASM module's import table instead of scanning user source code. Return-value commands are detected as real imports in the `env` module, while void commands use per-opcode marker imports in the `w` module. This ensures exact detection, even with aliases or macros. (`src/cli/generators.cc`, `src/cli/generators.h`, `src/cli/main.cc`, `docs/architecture.md`) [[1]](diffhunk://#diff-6ebe908315d8467b03c9e4390c789f0dd7c9fb774b38fb78fd9fe2dbba16c289L682-L746) [[2]](diffhunk://#diff-a607d508c0a5e7e96f3392f39b4968c2b996812ea75d4eeae0dd74347ebec5c1L30-R33) [[3]](diffhunk://#diff-d0ac0209e2b5ae3d91b31a6deb9df46a62316877a345a0e88f59e3b93c193601L106-R135) [[4]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L25-R32)
* For each void command, a never-called marker import is generated and parked in a `used` static in the wrapper. The marker's presence in the import table signals usage. The JS runtime supplies a shared no-op stub for all such markers via a Proxy. (`src/cli/generators.cc`, `src/cli/js_templates.h`) [[1]](diffhunk://#diff-6ebe908315d8467b03c9e4390c789f0dd7c9fb774b38fb78fd9fe2dbba16c289R465-R475) [[2]](diffhunk://#diff-6ebe908315d8467b03c9e4390c789f0dd7c9fb774b38fb78fd9fe2dbba16c289R523) [[3]](diffhunk://#diff-79a618c31f59a472a9b0e3ad6eb0be7572e1c0b439b9541779c99ad2120b576cR24) [[4]](diffhunk://#diff-79a618c31f59a472a9b0e3ad6eb0be7572e1c0b439b9541779c99ad2120b576cR35-R43) [[5]](diffhunk://#diff-6ebe908315d8467b03c9e4390c789f0dd7c9fb774b38fb78fd9fe2dbba16c289R805-R808) [[6]](diffhunk://#diff-6ebe908315d8467b03c9e4390c789f0dd7c9fb774b38fb78fd9fe2dbba16c289L841-R859)

**Code and build system changes:**

* The build system and code now include a new `wasm.cc` file for improved modularity. (`build.ninja`, `src/cli/main.cc`) [[1]](diffhunk://#diff-e98202262dc5a1c181b2494cb7ef44f48ef5614dee7e4b97d5ab913f023abdd8R23-R25) [[2]](diffhunk://#diff-d0ac0209e2b5ae3d91b31a6deb9df46a62316877a345a0e88f59e3b93c193601R5)
* The JS runtime generator interface and result handling are updated to reflect the new detection method; the `JsGenResult` struct is removed, and `required_wasm_exports()` provides the constant export set. (`src/cli/generators.h`, `src/cli/generators.cc`, `src/cli/main.cc`) [[1]](diffhunk://#diff-a607d508c0a5e7e96f3392f39b4968c2b996812ea75d4eeae0dd74347ebec5c1L10-R12) [[2]](diffhunk://#diff-6ebe908315d8467b03c9e4390c789f0dd7c9fb774b38fb78fd9fe2dbba16c289L682-L746) [[3]](diffhunk://#diff-d0ac0209e2b5ae3d91b31a6deb9df46a62316877a345a0e88f59e3b93c193601L106-R135)

**Build cache correctness:**

* The object file cache now checks the toolchain binary's mtime in addition to source mtimes. This prevents stale objects from causing incorrect feature detection after a toolchain rebuild or header regeneration. (`src/cli/generators.cc`) [[1]](diffhunk://#diff-6ebe908315d8467b03c9e4390c789f0dd7c9fb774b38fb78fd9fe2dbba16c289R1241-R1252) [[2]](diffhunk://#diff-6ebe908315d8467b03c9e4390c789f0dd7c9fb774b38fb78fd9fe2dbba16c289L1248-R1269)

**Other improvements:**

* Success messages and some code comments are updated for clarity and accuracy. (`src/cli/generators.cc`)

These changes make feature detection more reliable and maintainable, improve incremental build correctness, and lay groundwork for future extensibility.
This pull request overhauls how WebCC detects which C++ commands (features) are used in a project, making detection exact and immune to source-level tricks like macros or compat headers. Previously, void commands (those that don't return a value) were detected by scanning the user's source code, which was error-prone. Now, both return-value and void commands are detected by inspecting the linked WebAssembly module's import table: return-value commands appear as real imports, and void commands leave marker imports that are never called but are present if and only if the command is used. This change also updates the JS runtime to provide these marker imports and ensures the object cache is invalidated if the toolchain updates, preventing stale detection.

**Feature detection overhaul:**

* Both return-value and void commands are now detected from the linked WebAssembly module's import table, eliminating all source text scanning. Void commands emit a per-opcode imported marker function, referenced in the wrapper but never called, so their presence in the import table signals usage precisely. (`docs/architecture.md`, `src/cli/generators.cc`, `src/cli/generators.h`, `src/cli/main.cc`) [[1]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L25-R32) [[2]](diffhunk://#diff-6ebe908315d8467b03c9e4390c789f0dd7c9fb774b38fb78fd9fe2dbba16c289R465-R475) [[3]](diffhunk://#diff-6ebe908315d8467b03c9e4390c789f0dd7c9fb774b38fb78fd9fe2dbba16c289R523) [[4]](diffhunk://#diff-6ebe908315d8467b03c9e4390c789f0dd7c9fb774b38fb78fd9fe2dbba16c289L682-L747) [[5]](diffhunk://#diff-6ebe908315d8467b03c9e4390c789f0dd7c9fb774b38fb78fd9fe2dbba16c289L767-R713) [[6]](diffhunk://#diff-6ebe908315d8467b03c9e4390c789f0dd7c9fb774b38fb78fd9fe2dbba16c289R724-R747) [[7]](diffhunk://#diff-6ebe908315d8467b03c9e4390c789f0dd7c9fb774b38fb78fd9fe2dbba16c289L871-R808) [[8]](diffhunk://#diff-6ebe908315d8467b03c9e4390c789f0dd7c9fb774b38fb78fd9fe2dbba16c289L913-R858) [[9]](diffhunk://#diff-a607d508c0a5e7e96f3392f39b4968c2b996812ea75d4eeae0dd74347ebec5c1L28-R33) [[10]](diffhunk://#diff-d0ac0209e2b5ae3d91b31a6deb9df46a62316877a345a0e88f59e3b93c193601L107-R130)

* The old function for stripping comments and strings from user code, used for the previous detection method, has been removed as it is no longer needed. (`src/cli/generators.cc`)

**JavaScript runtime changes:**

* The generated JS runtime now provides a "w" import module whose fields are all no-op functions, satisfying the marker imports for void commands. This is implemented as a Proxy that returns a shared no-op for any marker name. (`src/cli/generators.cc`, `src/cli/js_templates.h`, `tests/snapshots/app_canvas.js`, `tests/snapshots/app_dom.js`) [[1]](diffhunk://#diff-6ebe908315d8467b03c9e4390c789f0dd7c9fb774b38fb78fd9fe2dbba16c289L913-R858) [[2]](diffhunk://#diff-79a618c31f59a472a9b0e3ad6eb0be7572e1c0b439b9541779c99ad2120b576cR24) [[3]](diffhunk://#diff-79a618c31f59a472a9b0e3ad6eb0be7572e1c0b439b9541779c99ad2120b576cR35-R43) [[4]](diffhunk://#diff-adc2d288dc2eb0f1bca769607a6ba78fa9bd1d9d696cb2c1d2d0d738c1a76aa3R17) [[5]](diffhunk://#diff-adc2d288dc2eb0f1bca769607a6ba78fa9bd1d9d696cb2c1d2d0d738c1a76aa3L35-R37) [[6]](diffhunk://#diff-f10085b1f78b5e1f1b90bc8223bfbeab039f67fd55841267ad57ff0da5a0c501R17) [[7]](diffhunk://#diff-f10085b1f78b5e1f1b90bc8223bfbeab039f67fd55841267ad57ff0da5a0c501L35-R37)

**Build and cache correctness:**

* The object file cache now also checks the modification time of the WebCC binary itself, ensuring that if the toolchain is rebuilt, all objects are recompiled to prevent stale feature detection due to outdated headers or codegen. (`src/cli/generators.cc`) [[1]](diffhunk://#diff-6ebe908315d8467b03c9e4390c789f0dd7c9fb774b38fb78fd9fe2dbba16c289R1241-R1252) [[2]](diffhunk://#diff-6ebe908315d8467b03c9e4390c789f0dd7c9fb774b38fb78fd9fe2dbba16c289L1311-R1269)

**Documentation updates:**

* The architecture documentation is updated to describe the new detection mechanism and how void-command markers work. (`docs/architecture.md`)

Overall, this makes feature detection robust, exact, and maintainable, and ensures the JS runtime always provides the correct imports for the user's code.