### PR TITLE
Implement heap allocator with management features and unit tests

### DIFF
--- a/examples/webcc_types/example.cc
+++ b/examples/webcc_types/example.cc
@@ -37,10 +37,10 @@ void log(const char* msg) {
 void draw_heap_viz() {
     if (!canvas_ctx.is_valid()) return;
 
-    uintptr_t base = (uintptr_t)&webcc::__heap_base;
-    uintptr_t current = webcc::heap_ptr;
-    size_t used = current - base;
-    
+    uintptr_t base = webcc::detail::backend_base();
+    uintptr_t current = webcc::detail::heap_ptr;
+    size_t used = webcc::detail::heap_used();
+
     // Get current memory size (in pages)
     size_t current_pages = __builtin_wasm_memory_size(0);
     size_t total_mem = current_pages * 64 * 1024;

--- a/include/webcc/core/allocator.h
+++ b/include/webcc/core/allocator.h
@@ -2,86 +2,380 @@
 #include <stdint.h>
 #include <stddef.h>
 
+// WebCC heap allocator.
+//
+// A boundary-tag free-list allocator: small fixed overhead per block, with
+// splitting on allocation and coalescing on free so the heap can shrink back
+// down instead of only ever growing. Tuned for the WebCC workload (lots of
+// growing vector/string buffers churning malloc+free).
+//
+// Layout of every block:
+//
+//     [ BlockHeader ][ payload (size bytes) ]
+//
+// The header is exactly 8 bytes on wasm32 (size_t + pointer), so payloads stay
+// 8-byte aligned and the per-allocation overhead matches the old bump
+// allocator. Blocks are threaded in physical (address) order via `prev_phys`,
+// which lets free() find and merge neighbours in O(1). Free blocks additionally
+// store their free-list links inside their (otherwise unused) payload, so the
+// free list costs no extra space.
+//
+// The WASM-specific bits (linear memory growth, `__heap_base`) live behind a
+// small backend so the allocator also compiles and runs host-native for tests.
+
 namespace webcc
 {
-    // The linker provides this symbol to mark the start of free RAM
-    extern "C" uint8_t __heap_base;
-
-    // We use a pointer to keep track of the next free address
-    inline uintptr_t heap_ptr = (uintptr_t)&__heap_base;
-
-    // Simple Free List Allocator
-    struct BlockHeader {
-        size_t size;
-        BlockHeader* next;
+    struct BlockHeader
+    {
+        // payload size in bytes (8-aligned, low 3 bits free); bit 0 = is-free
+        size_t size_flags;
+        BlockHeader *prev_phys; // previous block in address order (null if first)
     };
 
-    inline BlockHeader* free_list = nullptr;
+    namespace detail
+    {
+        constexpr size_t ALIGN = 8;
+        constexpr size_t FREE_BIT = 1;
+        constexpr size_t HEADER_SIZE = sizeof(BlockHeader);
+        // Free blocks stash two list pointers in their payload, so every block
+        // must be able to hold them once freed.
+        constexpr size_t MIN_PAYLOAD = 2 * sizeof(void *);
+
+        inline size_t align_up(size_t n) { return (n + (ALIGN - 1)) & ~(size_t)(ALIGN - 1); }
+
+        // --- Memory backend ----------------------------------------------------
+        // Provides the base address and the committed end of the heap region, and
+        // a way to commit more. On WASM this maps to linear memory + memory.grow;
+        // host builds use a fixed static arena so the allocator is unit-testable.
+#if defined(__wasm__)
+        extern "C" uint8_t __heap_base; // linker symbol: start of free RAM
+        inline uintptr_t backend_base() { return (uintptr_t)&__heap_base; }
+        inline uintptr_t backend_end() { return (uintptr_t)((size_t)__builtin_wasm_memory_size(0) * 65536u); }
+        inline bool backend_grow(size_t extra_bytes)
+        {
+            size_t pages = (extra_bytes + 65535) / 65536;
+            return __builtin_wasm_memory_grow(0, pages) != (size_t)-1;
+        }
+#else
+        constexpr size_t HOST_ARENA_BYTES = 64u * 1024u * 1024u;
+        alignas(16) inline uint8_t g_host_arena[HOST_ARENA_BYTES];
+        inline size_t g_host_committed = 0; // bytes "grown" so far, emulating memory.grow
+        inline uintptr_t backend_base() { return (uintptr_t)g_host_arena; }
+        inline uintptr_t backend_end() { return (uintptr_t)g_host_arena + g_host_committed; }
+        inline bool backend_grow(size_t extra_bytes)
+        {
+            size_t pages = (extra_bytes + 65535) / 65536;
+            size_t add = pages * 65536;
+            if (g_host_committed + add > HOST_ARENA_BYTES)
+                return false;
+            g_host_committed += add;
+            return true;
+        }
+#endif
+
+        // --- Allocator state ---------------------------------------------------
+        inline uintptr_t heap_ptr = align_up(backend_base()); // top of the bump region
+        inline BlockHeader *last_block = nullptr;             // block bordering the wilderness
+        inline BlockHeader *free_head = nullptr;              // head of the free list
+
+        // --- Block helpers -----------------------------------------------------
+        inline size_t blk_size(BlockHeader *b) { return b->size_flags & ~(size_t)(ALIGN - 1); }
+        inline bool blk_free(BlockHeader *b) { return b->size_flags & FREE_BIT; }
+        inline void set_blk(BlockHeader *b, size_t size, bool is_free)
+        {
+            b->size_flags = size | (is_free ? FREE_BIT : 0);
+        }
+        inline void *payload(BlockHeader *b) { return (uint8_t *)b + HEADER_SIZE; }
+        inline BlockHeader *hdr_of(void *p) { return (BlockHeader *)((uint8_t *)p - HEADER_SIZE); }
+
+        // Next physical block, or null if `b` borders the wilderness (the top).
+        inline BlockHeader *next_phys(BlockHeader *b)
+        {
+            uintptr_t end = (uintptr_t)b + HEADER_SIZE + blk_size(b);
+            return end < heap_ptr ? (BlockHeader *)end : nullptr;
+        }
+
+        // Free-list links live in the payload of free blocks.
+        struct FreeLinks
+        {
+            BlockHeader *prev;
+            BlockHeader *next;
+        };
+        inline FreeLinks *links(BlockHeader *b) { return (FreeLinks *)payload(b); }
+
+        inline void fl_insert(BlockHeader *b)
+        {
+            FreeLinks *l = links(b);
+            l->prev = nullptr;
+            l->next = free_head;
+            if (free_head)
+                links(free_head)->prev = b;
+            free_head = b;
+            set_blk(b, blk_size(b), true);
+        }
+
+        inline void fl_remove(BlockHeader *b)
+        {
+            FreeLinks *l = links(b);
+            if (l->prev)
+                links(l->prev)->next = l->next;
+            else
+                free_head = l->next;
+            if (l->next)
+                links(l->next)->prev = l->prev;
+            set_blk(b, blk_size(b), false);
+        }
+
+        inline bool ensure_capacity(uintptr_t new_top)
+        {
+            if (new_top <= backend_end())
+                return true;
+            return backend_grow(new_top - backend_end());
+        }
+
+        inline void mem_copy(void *dst, const void *src, size_t n)
+        {
+            uint8_t *d = (uint8_t *)dst;
+            const uint8_t *s = (const uint8_t *)src;
+            while (n--)
+                *d++ = *s++;
+        }
+
+        // Forward declaration: place() releases its split-off tail through free().
+        inline void heap_free(void *ptr);
+
+        // Trim `b` (an allocated block) to `size`, returning any usable tail to
+        // the free list. Returns the payload pointer.
+        inline void *place(BlockHeader *b, size_t size)
+        {
+            size_t total = blk_size(b);
+            if (total >= size + HEADER_SIZE + MIN_PAYLOAD)
+            {
+                set_blk(b, size, false);
+                BlockHeader *rem = (BlockHeader *)((uint8_t *)b + HEADER_SIZE + size);
+                rem->prev_phys = b;
+                set_blk(rem, total - size - HEADER_SIZE, false);
+                if (b == last_block)
+                {
+                    last_block = rem; // the tail now borders the wilderness
+                }
+                else
+                {
+                    BlockHeader *nx = next_phys(rem);
+                    if (nx)
+                        nx->prev_phys = rem;
+                }
+                heap_free(payload(rem)); // coalesce forward / reclaim wilderness / insert
+            }
+            return payload(b);
+        }
+
+        // Enlarge an allocated block to `size` payload bytes without moving it.
+        // `size` must already be aligned, >= MIN_PAYLOAD and > the block's current
+        // size. Returns true on success. Shared by realloc() and try_grow_inplace().
+        inline bool grow_inplace(BlockHeader *b, size_t size)
+        {
+            size_t cur = blk_size(b);
+
+            // Absorb a free next neighbour.
+            BlockHeader *nx = next_phys(b);
+            if (nx && blk_free(nx) && cur + HEADER_SIZE + blk_size(nx) >= size)
+            {
+                fl_remove(nx);
+                BlockHeader *after = next_phys(nx);
+                if (nx == last_block)
+                    last_block = b;
+                else if (after)
+                    after->prev_phys = b;
+                set_blk(b, cur + HEADER_SIZE + blk_size(nx), false);
+                place(b, size); // split off any excess
+                return true;
+            }
+
+            // Extend into the wilderness if we are the top block.
+            if (b == last_block)
+            {
+                uintptr_t new_top = (uintptr_t)b + HEADER_SIZE + size;
+                if (ensure_capacity(new_top))
+                {
+                    set_blk(b, size, false);
+                    heap_ptr = new_top;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    } // namespace detail
 
     inline void *malloc(size_t size)
     {
-        if (size == 0) return nullptr;
+        using namespace detail;
+        if (size == 0 || size > SIZE_MAX - HEADER_SIZE - MIN_PAYLOAD)
+            return nullptr;
 
-        // Align to 8 bytes
-        size = (size + 7) & ~7;
-        
-        // Total size needed including header
-        size_t total_size = size + sizeof(BlockHeader);
+        size = align_up(size);
+        if (size < MIN_PAYLOAD)
+            size = MIN_PAYLOAD;
 
-        // 1. Check free list for a suitable block
-        BlockHeader* prev = nullptr;
-        BlockHeader* curr = free_list;
-        
-        while (curr) {
-            if (curr->size >= size) { // Found a block big enough
-                // Unlink from list
-                if (prev) prev->next = curr->next;
-                else free_list = curr->next;
-                
-                // Return pointer to data (after header)
-                return (void*)((uint8_t*)curr + sizeof(BlockHeader));
-            }
-            prev = curr;
-            curr = curr->next;
-        }
-
-        // 2. Allocate from heap if no free block found
-        uintptr_t current = heap_ptr;
-        heap_ptr += total_size;
-
-        // Check current WASM memory limit
-        size_t current_pages = __builtin_wasm_memory_size(0);
-        uintptr_t max_mem = current_pages * 64 * 1024;
-
-        // If we've exceeded current memory, grow it
-        if (heap_ptr > max_mem)
+        // 1. First-fit search of the free list.
+        for (BlockHeader *b = free_head; b; b = links(b)->next)
         {
-            size_t bytes_needed = heap_ptr - max_mem;
-            size_t pages_to_add = (bytes_needed + 65535) / 65536;
-
-            if (__builtin_wasm_memory_grow(0, pages_to_add) == -1)
+            if (blk_size(b) >= size)
             {
-                heap_ptr = current; // Reset pointer
-                return nullptr;
+                fl_remove(b);
+                return place(b, size);
             }
         }
 
-        BlockHeader* header = (BlockHeader*)current;
-        header->size = size;
-        header->next = nullptr;
+        // 2. Bump a fresh block off the wilderness, growing memory if needed.
+        uintptr_t cur_top = heap_ptr;
+        uintptr_t new_top = cur_top + HEADER_SIZE + size;
+        if (!ensure_capacity(new_top))
+            return nullptr;
 
-        return (void*)((uint8_t*)header + sizeof(BlockHeader));
+        BlockHeader *b = (BlockHeader *)cur_top;
+        b->prev_phys = last_block;
+        set_blk(b, size, false);
+        heap_ptr = new_top;
+        last_block = b;
+        return payload(b);
     }
 
-    inline void free(void *ptr)
+    namespace detail
     {
-        if (!ptr) return;
-        
-        // Get header
-        BlockHeader* header = (BlockHeader*)((uint8_t*)ptr - sizeof(BlockHeader));
-        
-        // Add to front of free list
-        header->next = free_list;
-        free_list = header;
+        inline void heap_free(void *ptr)
+        {
+            if (!ptr)
+                return;
+
+            BlockHeader *b = hdr_of(ptr);
+
+            // Coalesce with the next physical block if it is free.
+            BlockHeader *nx = next_phys(b);
+            if (nx && blk_free(nx))
+            {
+                fl_remove(nx);
+                if (nx == last_block)
+                    last_block = b;
+                set_blk(b, blk_size(b) + HEADER_SIZE + blk_size(nx), false);
+                BlockHeader *after = next_phys(b);
+                if (after)
+                    after->prev_phys = b;
+            }
+
+            // Coalesce with the previous physical block if it is free.
+            BlockHeader *pv = b->prev_phys;
+            if (pv && blk_free(pv))
+            {
+                fl_remove(pv);
+                if (b == last_block)
+                    last_block = pv;
+                set_blk(pv, blk_size(pv) + HEADER_SIZE + blk_size(b), false);
+                BlockHeader *after = next_phys(pv);
+                if (after)
+                    after->prev_phys = pv;
+                b = pv;
+            }
+
+            // If the (possibly merged) block borders the wilderness, give it back
+            // to the bump pointer instead of holding it on the free list.
+            if (b == last_block)
+            {
+                heap_ptr = (uintptr_t)b;
+                last_block = b->prev_phys;
+                return;
+            }
+
+            fl_insert(b);
+        }
+    } // namespace detail
+
+    inline void free(void *ptr) { detail::heap_free(ptr); }
+
+    inline void *realloc(void *ptr, size_t size)
+    {
+        using namespace detail;
+        if (!ptr)
+            return malloc(size);
+        if (size == 0)
+        {
+            free(ptr);
+            return nullptr;
+        }
+        if (size > SIZE_MAX - HEADER_SIZE - MIN_PAYLOAD)
+            return nullptr;
+
+        size = align_up(size);
+        if (size < MIN_PAYLOAD)
+            size = MIN_PAYLOAD;
+
+        BlockHeader *b = hdr_of(ptr);
+        size_t cur = blk_size(b);
+
+        // Shrinking (or same size): trim in place, releasing the tail.
+        if (cur >= size)
+            return place(b, size);
+
+        // Growing: try to do it in place (no copy) first.
+        if (grow_inplace(b, size))
+            return ptr;
+
+        // Fall back to allocate + copy + free.
+        void *np = malloc(size);
+        if (!np)
+            return nullptr;
+        mem_copy(np, ptr, cur < size ? cur : size);
+        free(ptr);
+        return np;
     }
+
+    // Enlarge an existing allocation to at least `size` bytes WITHOUT moving any
+    // bytes, returning true on success and false if it could not grow in place.
+    // Unlike realloc this never relocates, so it is safe for element types whose
+    // move/copy constructors must run (the caller relocates them itself on a
+    // false result). Returns false for a null pointer.
+    inline bool try_grow_inplace(void *ptr, size_t size)
+    {
+        using namespace detail;
+        if (!ptr || size == 0 || size > SIZE_MAX - HEADER_SIZE - MIN_PAYLOAD)
+            return false;
+        size = align_up(size);
+        if (size < MIN_PAYLOAD)
+            size = MIN_PAYLOAD;
+        BlockHeader *b = hdr_of(ptr);
+        if (blk_size(b) >= size)
+            return true; // already big enough
+        return grow_inplace(b, size);
+    }
+
+    namespace detail
+    {
+        // Introspection helpers (used by tests; tree-shaken when unused).
+        inline size_t heap_used() { return (size_t)(heap_ptr - align_up(backend_base())); }
+        inline size_t free_block_count()
+        {
+            size_t n = 0;
+            for (BlockHeader *b = free_head; b; b = links(b)->next)
+                ++n;
+            return n;
+        }
+        inline size_t free_bytes()
+        {
+            size_t s = 0;
+            for (BlockHeader *b = free_head; b; b = links(b)->next)
+                s += blk_size(b);
+            return s;
+        }
+#if !defined(__wasm__)
+        // Reset all allocator state. Host/test builds only.
+        inline void heap_reset()
+        {
+            g_host_committed = 0;
+            heap_ptr = align_up(backend_base());
+            last_block = nullptr;
+            free_head = nullptr;
+        }
+#endif
+    } // namespace detail
 } // namespace webcc

--- a/include/webcc/core/format.h
+++ b/include/webcc/core/format.h
@@ -178,15 +178,14 @@ private:
 
     void ensure_capacity(size_t needed) {
         if (m_pos + needed < m_capacity) return;
-        
+
         size_t new_cap = m_capacity == 0 ? 256 : m_capacity * 2;
         while (new_cap < m_pos + needed + 1) new_cap *= 2;
-        
-        char* new_data = (char*)webcc::malloc(new_cap);
-        if (m_data) {
-            for (size_t i = 0; i < m_pos; ++i) new_data[i] = m_data[i];
-            webcc::free(m_data);
-        }
+
+        // realloc grows in place when it can; otherwise it copies the existing
+        // bytes across for us. realloc(nullptr, ...) is just malloc.
+        char* new_data = (char*)webcc::realloc(m_data, new_cap);
+        if (!new_data) return; // allocation failed; keep the old buffer intact
         m_data = new_data;
         m_capacity = new_cap;
     }
@@ -290,23 +289,27 @@ private:
 
     void ensure_capacity(size_t needed) {
         if (m_pos + needed < m_capacity) return;
-        
+
         // Need to grow - switch to heap or grow heap
         size_t new_cap = m_capacity * 2;
         while (new_cap < m_pos + needed + 1) new_cap *= 2;
-        
-        char* new_data = (char*)webcc::malloc(new_cap);
-        
-        // Copy existing data
-        char* src = buffer();
-        for (size_t i = 0; i < m_pos; ++i) new_data[i] = src[i];
-        
-        // Free old heap if we had one
-        if (m_on_heap && m_heap) webcc::free(m_heap);
-        
-        m_heap = new_data;
+
+        if (m_on_heap) {
+            // Already on the heap: realloc grows in place when possible.
+            char* new_data = (char*)webcc::realloc(m_heap, new_cap);
+            if (!new_data) return; // keep the old buffer on failure
+            m_heap = new_data;
+        } else {
+            // First overflow off the stack buffer: must copy out of it (the
+            // stack storage isn't owned by the allocator, so realloc can't move it).
+            char* new_data = (char*)webcc::malloc(new_cap);
+            if (!new_data) return;
+            for (size_t i = 0; i < m_pos; ++i) new_data[i] = m_stack[i];
+            m_heap = new_data;
+            m_on_heap = true;
+        }
+
         m_capacity = new_cap;
-        m_on_heap = true;
     }
 
 public:

--- a/include/webcc/core/new.h
+++ b/include/webcc/core/new.h
@@ -1,11 +1,10 @@
 #pragma once
-#include <stddef.h>
 
-// Placement new operators for nostdlib environments
-// 
+// Placement new operators.
+//
 // These operators don't allocate memory - they just return the pointer you give them.
 // The actual object construction is handled by compiler-generated code.
-// 
+//
 // Usage: ::new (buffer) T(args);
 //   - Constructs object T at the address 'buffer' (which you already allocated)
 //   - The operator new function below just returns 'buffer' unchanged
@@ -14,12 +13,21 @@
 // The delete operators are only called if a constructor throws an exception.
 // They're empty because placement new doesn't allocate, so there's nothing to free.
 
+#if defined(__wasm__)
+// Freestanding WASM build (-nostdlib): no <new>, so define the shims ourselves.
+#include <stddef.h>
+
 // Placement new
-inline void* operator new(size_t, void* p) noexcept { return p; }
+inline void *operator new(size_t, void *p) noexcept { return p; }
 
 // Placement delete (called if constructor throws exception)
-inline void operator delete(void*, void*) noexcept { }
+inline void operator delete(void *, void *) noexcept {}
 
-// Array versions 
-inline void* operator new[](size_t, void* p) noexcept { return p; }
-inline void operator delete[](void*, void*) noexcept { }
+// Array versions
+inline void *operator new[](size_t, void *p) noexcept { return p; }
+inline void operator delete[](void *, void *) noexcept {}
+#else
+// Hosted build (e.g. native unit tests): the standard library already provides
+// the placement new/delete operators; pulling them in here avoids redefining them.
+#include <new>
+#endif

--- a/include/webcc/core/queue.h
+++ b/include/webcc/core/queue.h
@@ -18,6 +18,19 @@ namespace webcc
 
         void reallocate(size_t new_capacity)
         {
+            // Fast path: grow in place only when the ring is laid out linearly
+            // from index 0 (m_head == 0). Then the existing elements already sit
+            // at [0, m_size) and stay valid under the larger power-of-two mask, so
+            // no relinearization or element moves are needed. A wrapped/offset
+            // ring must fall through to the relinearizing copy below.
+            if (m_data && m_head == 0 && new_capacity > m_capacity &&
+                webcc::try_grow_inplace(m_data, new_capacity * sizeof(T)))
+            {
+                m_capacity = new_capacity;
+                m_tail = m_size;
+                return;
+            }
+
             T* new_data = (T*)webcc::malloc(new_capacity * sizeof(T));
             
             // Copy elements in order from head to tail

--- a/include/webcc/core/vector.h
+++ b/include/webcc/core/vector.h
@@ -18,6 +18,16 @@ namespace webcc
 
         void reallocate(size_t new_capacity)
         {
+            // Fast path: enlarge the existing block in place. No element moves,
+            // so this is safe for every T (no constructors run) and avoids the
+            // allocate-copy-free round trip entirely when the block can grow.
+            if (m_data && new_capacity > m_capacity &&
+                webcc::try_grow_inplace(m_data, new_capacity * sizeof(T)))
+            {
+                m_capacity = new_capacity;
+                return;
+            }
+
             // 1. Allocate new block
             T *new_block = (T *)webcc::malloc(new_capacity * sizeof(T));
             if (!new_block)

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -27,13 +27,15 @@ CXX="${CXX:-clang++}"
 
 echo "[tests] Compiling C++ test suite..."
 "$CXX" -std=c++20 -O1 -g \
-    -I "$ROOT/src/cli" -I "$ROOT/src/core" \
+    -I "$ROOT/src/cli" -I "$ROOT/src/core" -I "$ROOT/include" \
     -DWEBCC_SCHEMA_DEF="\"$ROOT/schema.def\"" \
     -DWEBCC_SNAPSHOT_DIR="\"$ROOT/tests/snapshots\"" \
     "$ROOT/tests/test_main.cc" \
     "$ROOT/tests/test_command_buffer.cc" \
     "$ROOT/tests/test_schema.cc" \
     "$ROOT/tests/test_codegen.cc" \
+    "$ROOT/tests/test_allocator.cc" \
+    "$ROOT/tests/test_containers.cc" \
     "$ROOT/src/cli/schema.cc" \
     "$ROOT/src/cli/utils.cc" \
     "$ROOT/src/cli/generators.cc" \

--- a/tests/test_allocator.cc
+++ b/tests/test_allocator.cc
@@ -1,0 +1,211 @@
+// Unit tests for the WebCC heap allocator (include/webcc/core/allocator.h).
+//
+// The allocator's WASM backend is swapped for a fixed static arena on host
+// builds (see the #if defined(__wasm__) guard in allocator.h), so the splitting,
+// coalescing, reclaim and realloc logic can be exercised natively here. Each
+// test starts from a clean heap via detail::heap_reset().
+
+#include "webcc/core/allocator.h"
+#include "framework.h"
+
+#include <cstdint>
+
+using webcc::detail::free_block_count;
+using webcc::detail::free_bytes;
+using webcc::detail::heap_reset;
+using webcc::detail::heap_used;
+
+namespace
+{
+    bool aligned8(void *p) { return ((uintptr_t)p % 8) == 0; }
+}
+
+TEST(alloc_basic_roundtrip)
+{
+    heap_reset();
+    int *p = (int *)webcc::malloc(sizeof(int) * 4);
+    CHECK(p != nullptr);
+    for (int i = 0; i < 4; ++i)
+        p[i] = i * 7;
+    for (int i = 0; i < 4; ++i)
+        CHECK_EQ(p[i], i * 7);
+    webcc::free(p);
+    // A lone block bordering the wilderness is reclaimed, not leaked.
+    CHECK_EQ(heap_used(), (size_t)0);
+}
+
+TEST(alloc_returns_8byte_aligned)
+{
+    heap_reset();
+    for (size_t s = 1; s <= 64; ++s)
+    {
+        void *p = webcc::malloc(s);
+        CHECK(p != nullptr);
+        CHECK(aligned8(p));
+    }
+}
+
+TEST(zero_size_returns_null)
+{
+    heap_reset();
+    CHECK(webcc::malloc(0) == nullptr);
+    webcc::free(nullptr); // must be a no-op
+}
+
+TEST(free_block_is_reused_and_split)
+{
+    heap_reset();
+    // Keep a guard at the top so the freed block lands on the free list
+    // (instead of being reclaimed straight into the wilderness).
+    void *guard = webcc::malloc(16);
+    void *big = webcc::malloc(1024);
+    void *top = webcc::malloc(16);
+    (void)guard;
+    (void)top;
+
+    size_t used_before = heap_used();
+    webcc::free(big);
+    CHECK_EQ(free_block_count(), (size_t)1);
+    CHECK(free_bytes() >= 1024);
+
+    // A small request must carve out of the freed 1KB block and return the
+    // remainder to the free list — no new memory, and the leftover survives.
+    void *small = webcc::malloc(32);
+    CHECK(small != nullptr);
+    CHECK_EQ(heap_used(), used_before); // reused, did not grow
+    CHECK_EQ(free_block_count(), (size_t)1);
+    CHECK(free_bytes() >= 1024 - 32 - 64); // remainder kept (minus header slack)
+}
+
+TEST(adjacent_frees_coalesce_and_reclaim)
+{
+    heap_reset();
+    void *a = webcc::malloc(64);
+    void *b = webcc::malloc(64);
+    void *c = webcc::malloc(64);
+    void *d = webcc::malloc(64);
+    CHECK(a && b && c && d);
+
+    // Free the middle two: they must merge into a single free block.
+    webcc::free(b);
+    webcc::free(c);
+    CHECK_EQ(free_block_count(), (size_t)1);
+
+    // Freeing the rest must coalesce everything and hand it back to the
+    // wilderness, leaving the heap empty.
+    webcc::free(a);
+    webcc::free(d);
+    CHECK_EQ(heap_used(), (size_t)0);
+    CHECK_EQ(free_block_count(), (size_t)0);
+}
+
+TEST(realloc_grows_top_block_in_place)
+{
+    heap_reset();
+    char *p = (char *)webcc::malloc(16);
+    for (int i = 0; i < 16; ++i)
+        p[i] = (char)(i + 1);
+
+    char *q = (char *)webcc::realloc(p, 64);
+    CHECK_EQ((void *)q, (void *)p); // top block, grown in place
+    for (int i = 0; i < 16; ++i)
+        CHECK_EQ((int)q[i], i + 1); // data preserved
+
+    // Shrinking trims in place too.
+    char *r = (char *)webcc::realloc(q, 16);
+    CHECK_EQ((void *)r, (void *)q);
+}
+
+TEST(realloc_relocates_and_preserves_data)
+{
+    heap_reset();
+    char *p = (char *)webcc::malloc(16);
+    for (int i = 0; i < 16; ++i)
+        p[i] = (char)(i + 100);
+    void *guard = webcc::malloc(16); // pins p: not top, no free neighbour
+    (void)guard;
+
+    char *q = (char *)webcc::realloc(p, 128);
+    CHECK(q != nullptr);
+    CHECK(q != p); // had to move
+    for (int i = 0; i < 16; ++i)
+        CHECK_EQ((int)q[i], i + 100); // copied across
+}
+
+TEST(realloc_edge_cases)
+{
+    heap_reset();
+    void *p = webcc::realloc(nullptr, 32); // acts as malloc
+    CHECK(p != nullptr);
+    void *q = webcc::realloc(p, 0); // acts as free
+    CHECK(q == nullptr);
+    CHECK_EQ(heap_used(), (size_t)0);
+}
+
+TEST(try_grow_inplace_extends_top_block)
+{
+    heap_reset();
+    char *p = (char *)webcc::malloc(16);
+    for (int i = 0; i < 16; ++i)
+        p[i] = (char)(i + 1);
+
+    size_t used_before = heap_used();
+    CHECK(webcc::try_grow_inplace(p, 128)); // top block grows into wilderness
+    CHECK(heap_used() > used_before);        // it did extend
+    for (int i = 0; i < 16; ++i)
+        CHECK_EQ((int)p[i], i + 1); // bytes never moved
+}
+
+TEST(try_grow_inplace_absorbs_free_neighbour)
+{
+    heap_reset();
+    void *a = webcc::malloc(16);
+    void *b = webcc::malloc(64);
+    void *guard = webcc::malloc(16); // keep b off the top so it lands on the free list
+    (void)guard;
+    webcc::free(b); // a's next physical neighbour is now free
+
+    CHECK(webcc::try_grow_inplace(a, 64)); // absorbs the freed neighbour, no move
+}
+
+TEST(try_grow_inplace_fails_when_pinned)
+{
+    heap_reset();
+    CHECK(!webcc::try_grow_inplace(nullptr, 16));
+    void *p = webcc::malloc(16);
+    void *guard = webcc::malloc(16); // p is not the top and has no free neighbour
+    (void)guard;
+    CHECK(!webcc::try_grow_inplace(p, 64)); // cannot grow without relocating
+}
+
+// Headline regression: the growing-buffer churn that the old (no-split,
+// no-coalesce) allocator leaked on. Each "vector" grows by malloc(new) +
+// free(old) — exactly what webcc::vector/string do. With coalescing the
+// freed buffers merge and get reused, so the heap stays tiny no matter how
+// many vectors we build.
+TEST(vector_growth_churn_stays_bounded)
+{
+    heap_reset();
+    for (int v = 0; v < 2000; ++v)
+    {
+        void *data = nullptr;
+        size_t cap = 0;
+        for (size_t n = 1; n <= 512; ++n)
+        {
+            if (n > cap)
+            {
+                size_t new_cap = cap ? cap * 2 : 1;
+                void *nb = webcc::malloc(new_cap * 8);
+                CHECK(nb != nullptr);
+                if (data)
+                    webcc::free(data);
+                data = nb;
+                cap = new_cap;
+            }
+        }
+        webcc::free(data);
+    }
+    // The old allocator would have grown without bound here. A single vector's
+    // largest buffer is 512*8 = 4096 bytes; the whole run must stay near that.
+    CHECK(heap_used() < (size_t)16 * 1024);
+}

--- a/tests/test_containers.cc
+++ b/tests/test_containers.cc
@@ -1,0 +1,109 @@
+// Integration tests: the containers that grow via webcc::try_grow_inplace /
+// webcc::realloc must stay correct across reallocation, including for element
+// types whose move constructors and destructors must run (the in-place fast
+// path must never byte-copy those).
+
+#include "webcc/core/vector.h"
+#include "webcc/core/queue.h"
+#include "framework.h"
+
+using webcc::detail::heap_reset;
+using webcc::detail::heap_used;
+
+namespace
+{
+    // A non-trivially-movable element: owns a heap allocation. If the vector's
+    // in-place growth ever byte-copied these without running the move
+    // constructor, teardown would double-free and the heap would not return to
+    // empty.
+    struct Boxed
+    {
+        int *p = nullptr;
+        explicit Boxed(int v)
+        {
+            p = (int *)webcc::malloc(sizeof(int));
+            *p = v;
+        }
+        Boxed(Boxed &&o) noexcept : p(o.p) { o.p = nullptr; }
+        Boxed &operator=(Boxed &&o) noexcept
+        {
+            if (this != &o)
+            {
+                if (p)
+                    webcc::free(p);
+                p = o.p;
+                o.p = nullptr;
+            }
+            return *this;
+        }
+        Boxed(const Boxed &) = delete;
+        Boxed &operator=(const Boxed &) = delete;
+        ~Boxed()
+        {
+            if (p)
+                webcc::free(p);
+        }
+        int val() const { return p ? *p : -1; }
+    };
+}
+
+TEST(vector_int_growth_preserves_values)
+{
+    heap_reset();
+    webcc::vector<int> v;
+    for (int i = 0; i < 5000; ++i)
+        v.push_back(i * 3);
+    CHECK_EQ(v.size(), (size_t)5000);
+    for (int i = 0; i < 5000; ++i)
+        CHECK_EQ(v[i], i * 3);
+}
+
+TEST(vector_of_nontrivial_survives_growth)
+{
+    heap_reset();
+    {
+        webcc::vector<Boxed> v;
+        for (int i = 0; i < 200; ++i)
+            v.emplace_back(i);
+        for (int i = 0; i < 200; ++i)
+            CHECK_EQ(v[i].val(), i); // values intact across many reallocations
+    } // every Boxed (and the buffer) destroyed here
+    // No leak and no double free: the whole heap coalesces back to empty.
+    CHECK_EQ(heap_used(), (size_t)0);
+}
+
+TEST(queue_fifo_preserved_linear_growth)
+{
+    heap_reset();
+    webcc::queue<int> q; // m_head stays 0 -> in-place growth fast path
+    for (int i = 0; i < 2000; ++i)
+        q.push(i);
+    for (int i = 0; i < 2000; ++i)
+    {
+        CHECK_EQ(q.front(), i);
+        q.pop();
+    }
+    CHECK(q.empty());
+}
+
+TEST(queue_fifo_preserved_when_wrapped)
+{
+    heap_reset();
+    webcc::queue<int> q;
+    for (int i = 0; i < 8; ++i)
+        q.push(i);
+    for (int i = 0; i < 4; ++i) // advance head so the ring is offset
+    {
+        CHECK_EQ(q.front(), i);
+        q.pop();
+    }
+    // Growth now happens with m_head != 0 -> must take the relinearizing path.
+    for (int i = 8; i < 500; ++i)
+        q.push(i);
+    for (int i = 4; i < 500; ++i)
+    {
+        CHECK_EQ(q.front(), i);
+        q.pop();
+    }
+    CHECK(q.empty());
+}


### PR DESCRIPTION
This pull request introduces a new boundary-tag free-list heap allocator for WebCC, replacing the previous bump allocator and improving memory management across the codebase. The allocator now supports splitting and coalescing of blocks, in-place growth, and is testable on both WASM and host builds. Several core containers and formatters are updated to take advantage of the new allocator's features, and placement new support is improved for both freestanding and hosted environments.

### Heap Allocator Redesign and Improvements

* [`include/webcc/core/allocator.h`](diffhunk://#diff-bd10771928744a6c64d378f0bdbc45f48bc1ec2bcdd9cdc900b5854c2b50261cR5-R380): Replaces the old bump allocator with a boundary-tag free-list allocator, supporting block splitting on allocation, coalescing on free, and in-place growth of allocations. Introduces a platform-abstracted backend for both WASM and host builds, and provides new introspection helpers for testing.
* [`examples/webcc_types/example.cc`](diffhunk://#diff-0378a58a312f61c17814815a4b0e3828b493e432b20a87dac94afc7c847a633bL40-R42): Updates heap visualization code to use the new allocator's backend and introspection helpers.

### Container and Formatter Enhancements

* [`include/webcc/core/vector.h`](diffhunk://#diff-7f1d5cfb08de99c4f18ef7467e48b46078082132957e71ec986ca031fc6ccfefR21-R30): Updates `vector` to use the new `try_grow_inplace` API, allowing in-place capacity growth without unnecessary reallocations or element moves.
* [`include/webcc/core/queue.h`](diffhunk://#diff-c07b9db23a442be44337e1aedad22a371b7f1354813616120140bb98ff81dc61R21-R33): Updates `queue` to use in-place growth when possible, reducing memory copying and improving performance in the common case.
* [`include/webcc/core/format.h`](diffhunk://#diff-9ee51da0bcd04a394f769576442c08ebf423bf9a1e721cdaf571de25250600ceL185-R188): Refactors `dynamic_formatter` and `hybrid_formatter` to use `realloc` for buffer growth, leveraging in-place expansion and simplifying buffer management logic. [[1]](diffhunk://#diff-9ee51da0bcd04a394f769576442c08ebf423bf9a1e721cdaf571de25250600ceL185-R188) [[2]](diffhunk://#diff-9ee51da0bcd04a394f769576442c08ebf423bf9a1e721cdaf571de25250600ceR297-R314)

### Placement New Operator Support

* [`include/webcc/core/new.h`](diffhunk://#diff-82261c7bb3b71b0b04f6d0134769cc4b22047ca257733c55140e76c9186a63d4L2-R3): Improves placement new/delete support for both freestanding WASM and hosted builds, conditionally including the appropriate headers or definitions. [[1]](diffhunk://#diff-82261c7bb3b71b0b04f6d0134769cc4b22047ca257733c55140e76c9186a63d4L2-R3) [[2]](diffhunk://#diff-82261c7bb3b71b0b04f6d0134769cc4b22047ca257733c55140e76c9186a63d4R16-R19) [[3]](diffhunk://#diff-82261c7bb3b71b0b04f6d0134769cc4b22047ca257733c55140e76c9186a63d4R29-R33)

### Test Suite Updates

* [`tests/run.sh`](diffhunk://#diff-dd0c9cda3917fccebea6cea8d3fb46f46e4fbbeda2d6939864c9aaa9fc9c9571L30-R38): Adds compilation of new allocator and container tests, and ensures the correct include paths for the refactored code.