### PR TITLE
Add localStorage commands and documentation for get_item function

### DIFF
--- a/docs/api/storage.md
+++ b/docs/api/storage.md
@@ -18,6 +18,15 @@ Saves a key-value pair to local storage.
 void set_item(webcc::string_view key, webcc::string_view value);
 ```
 
+### `get_item`
+
+Reads a value from local storage by its key. Returns an empty string if the key
+does not exist.
+
+```cpp
+webcc::string get_item(webcc::string_view key);
+```
+
 ### `remove_item`
 
 Removes an item from local storage by its key.

--- a/schema.def
+++ b/schema.def
@@ -147,6 +147,7 @@ system|command|INIT_VISIBILITY_CHANGE|init_visibility_change||{ document.addEven
 # STORAGE (LocalStorage)
 # ------------------------------------------------------------------------------
 storage|command|SET_ITEM|set_item|string:key string:value|{ localStorage.setItem(key, value); }
+storage|command|GET_ITEM|get_item|string:key RET:string|{ const ret = localStorage.getItem(key) || ""; }
 storage|command|REMOVE_ITEM|remove_item|string:key|{ localStorage.removeItem(key); }
 storage|command|CLEAR|clear||{ localStorage.clear(); }
 


### PR DESCRIPTION
This pull request adds support for reading values from local storage in addition to the existing functionality for writing and removing items. The primary change is the introduction of a new `get_item` command and its documentation.

**Local Storage Enhancements:**

* Added a new `get_item` command to the storage schema, allowing retrieval of a value by key from local storage, returning an empty string if the key does not exist.
* Documented the new `get_item` function in `docs/api/storage.md`, including usage and return value details.