### PR TITLE
Add GET_TIMEZONE_OFFSET_MS command and documentation

### DIFF
--- a/docs/api/system.md
+++ b/docs/api/system.md
@@ -70,8 +70,12 @@ These functions provide access to the system time.
 // Returns the time in milliseconds since the page started loading (performance.now())
 double get_time();
 
-// Returns the number of milliseconds elapsed since the epoch (Date.now())
+// Returns the number of milliseconds elapsed since the epoch, UTC (Date.now())
 double get_date_now();
+
+// Returns the local timezone offset from UTC in milliseconds.
+// Add it to a UTC epoch-ms value to convert it to local time.
+double get_timezone_offset_ms();
 ```
 
 ## Visibility API

--- a/schema.def
+++ b/schema.def
@@ -132,6 +132,7 @@ system|command|RELOAD|reload||{ location.reload(); }
 system|command|OPEN_URL|open_url|string:url|{ window.open(url, '_blank'); }
 system|command|GET_TIME|get_time|RET:float64|{ return performance.now(); }
 system|command|GET_DATE_NOW|get_date_now|RET:float64|{ return Date.now(); }
+system|command|GET_TIMEZONE_OFFSET_MS|get_timezone_offset_ms|RET:float64|{ return -new Date().getTimezoneOffset()*60000; }
 system|command|GET_PATHNAME|get_pathname|RET:string|{ const ret = window.location.pathname || "/"; }
 system|command|GET_SEARCH|get_search|RET:string|{ const ret = window.location.search || ""; }
 system|command|GET_QUERY_PARAM|get_query_param|string:name RET:string|{ const ret = new URLSearchParams(window.location.search).get(name) || ""; }


### PR DESCRIPTION
This pull request adds support for retrieving the user's local timezone offset in milliseconds, enhancing the system time API. It updates both the documentation and the system command schema to include this new functionality.

**System time API enhancements:**

* Added a new function `get_timezone_offset_ms` that returns the local timezone offset from UTC in milliseconds, allowing conversion between UTC and local time. [[1]](diffhunk://#diff-c98c3799854bebfd02a5de942634d3fda312171c087368f31b9861f15d84bb43L73-R78) [[2]](diffhunk://#diff-7e080d651efc694c9ab3c3b1d2681bd66490c3b99bdcd45386c9e08cc06a31cfR135)

**Documentation updates:**

* Updated the system API documentation in `docs/api/system.md` to describe the new `get_timezone_offset_ms` function and clarified that `get_date_now` returns milliseconds since the epoch in UTC.